### PR TITLE
Jessie update tested

### DIFF
--- a/changelog
+++ b/changelog
@@ -1,3 +1,18 @@
+turnkey-bugzilla-14.0 (1) turnkey; urgency=low
+
+  * Bugzilla:
+
+      - Installed latest upstream source.
+    
+  * Upstream source component versions:
+
+    bugzilla    4.4.9
+
+  * Note: Please refer to turnkey-core's changelog for changes common to all
+    appliances. Here we only describe changes specific to this appliance.
+
+ -- Jeremy Davis <jeremy@turnkeylinux.org>  Sat, 06 Jun 2015 01:03:25 +1000
+
 turnkey-bugzilla-13.0 (1) turnkey; urgency=low
 
   * Bugzilla:

--- a/conf.d/downloads
+++ b/conf.d/downloads
@@ -5,6 +5,6 @@ dl() {
     cd $2; curl -L -f -O $PROXY $1; cd -
 }
 
-URL=http://ftp.mozilla.org/pub/mozilla.org/webtools/bugzilla-4.4.tar.gz
+URL=http://ftp.mozilla.org/pub/mozilla.org/webtools/bugzilla-STABLE.tar.gz
 dl $URL /usr/local/src
 

--- a/conf.d/main
+++ b/conf.d/main
@@ -17,7 +17,7 @@ chown -R www-data:www-data $WEBROOT
 rm $SRC/bugzilla-*.tar.gz
 
 # configure apache
-a2dissite default
+a2dissite 000-default
 a2ensite bugzilla
 a2enmod rewrite
 a2enmod headers

--- a/conf.d/main
+++ b/conf.d/main
@@ -65,13 +65,16 @@ cd $WEBROOT
 ./checksetup.pl $WEBROOT/answers
 rm $WEBROOT/answers
 
+# run collectstats - scripts so stats page doesn't error
+./collectstats.pl
+
 /etc/init.d/mysql stop
 
 # cron jobs
 echo "
-0 0 * * * (cd $WEBROOT/lib && ./collectstats.pl)
-0 0 * * * (cd $WEBROOT/lib && ./whineatnews.pl)
-0,15,30,45 * * * * (cd $WEBROOT/lib && ./whine.pl)
+0 0 * * * (cd $WEBROOT && ./collectstats.pl)
+0 0 * * * (cd $WEBROOT && ./whineatnews.pl)
+0,15,30,45 * * * * (cd $WEBROOT && ./whine.pl)
 " | crontab -u root -
 
 rm -rf /root/.cpan

--- a/conf.d/main
+++ b/conf.d/main
@@ -22,8 +22,7 @@ a2ensite bugzilla
 a2enmod rewrite
 a2enmod headers
 a2enmod expires
-
-perl install-module.pl Email::Send
+a2enmod cgid
 
 # setup the database
 /etc/init.d/mysql start
@@ -60,6 +59,8 @@ cat > $WEBROOT/answers <<EOF
 EOF
 
 cd $WEBROOT
+./install-module.pl Email::Send Daemon::Generic PatchReader JSON::XS Email::Reply XMLRPC::Lite
+
 ./checksetup.pl $WEBROOT/answers
 ./checksetup.pl $WEBROOT/answers
 rm $WEBROOT/answers
@@ -73,3 +74,6 @@ echo "
 0,15,30,45 * * * * (cd $WEBROOT/lib && ./whine.pl)
 " | crontab -u root -
 
+rm -rf /root/.cpan
+apt-get purge -y gcc make
+apt-get autoremove -y

--- a/conf.d/main
+++ b/conf.d/main
@@ -23,6 +23,8 @@ a2enmod rewrite
 a2enmod headers
 a2enmod expires
 
+perl install-module.pl Email::Send
+
 # setup the database
 /etc/init.d/mysql start
 MYSQL_BATCH="mysql --user=root --password=$MYSQL_PASS --batch"

--- a/overlay/etc/apache2/sites-available/bugzilla.conf
+++ b/overlay/etc/apache2/sites-available/bugzilla.conf
@@ -20,28 +20,24 @@ SetEnv X_BUGZILLA_WEBPATH "/"
     DirectoryIndex index.cgi
     Options +Indexes +ExecCGI -MultiViews +SymLinksIfOwnerMatch +FollowSymLinks
     AllowOverride None
-    Order allow,deny
-    Allow from all
+    Require all granted 
 </Directory>
 
 <Directory "/var/www/bugzilla/data">
     Options +FollowSymLinks -Indexes
     AllowOverride None
-    Order allow,deny
-    Allow from all
+    Require all granted
 </Directory>
 
 <Directory "/var/www/bugzilla/js">
     Options +FollowSymLinks -Indexes
     AllowOverride None
-    Order allow,deny
-    Allow from all
+    Require all granted
 </Directory>
 
 <Directory "/var/www/bugzilla/skins">
     Options +FollowSymLinks -Indexes
     AllowOverride None
-    Order allow,deny
-    Allow from all
+    Require all granted
 </Directory>
 

--- a/overlay/etc/apache2/sites-available/bugzilla.conf
+++ b/overlay/etc/apache2/sites-available/bugzilla.conf
@@ -1,5 +1,4 @@
-NameVirtualHost *:80
-NameVirtualHost *:443
+ServerName localhost
 
 SetEnv X_BUGZILLA_WEBPATH "/"
 

--- a/plan/main
+++ b/plan/main
@@ -55,6 +55,6 @@ libtemplate-perl-doc
 libfile-mimeinfo-perl 
 libhtml-formattext-withlinks-perl 
 libgd-dev 
-lynx-cur 
-python-sphinx
 
+gcc /* for installing perl modules via cpan */
+make

--- a/plan/main
+++ b/plan/main
@@ -3,7 +3,6 @@
 apache2-mpm-worker
 webmin-apache
 libapache2-mod-perl2
-
 mysql-client
 mysql-server
 webmin-mysql
@@ -11,8 +10,9 @@ libdbd-mysql-perl
 
 postfix
 webmin-postfix
-libemail-send-perl
 libemail-mime-perl
+libemail-sender-perl 
+libmime-tools-perl
 
 libdatetime-perl
 liburi-perl
@@ -22,4 +22,39 @@ libgd-graph-perl
 libchart-perl
 libtemplate-perl
 libtemplate-plugin-gd-perl
+
+libappconfig-perl 
+libdate-calc-perl 
+libdatetime-timezone-perl 
+libdatetime-perl 
+libdbi-perl 
+libdbd-mysql-perl 
+libcgi-pm-perl 
+libmath-random-isaac-perl 
+libmath-random-isaac-xs-perl 
+libapache2-mod-perl2 
+libapache2-mod-perl2-dev 
+libchart-perl 
+libxml-perl 
+libxml-twig-perl 
+perlmagick 
+libgd-graph-perl 
+libtemplate-plugin-gd-perl 
+libsoap-lite-perl 
+libhtml-scrubber-perl 
+libjson-rpc-perl 
+libtheschwartz-perl 
+libtest-taint-perl 
+libauthen-radius-perl 
+libfile-slurp-perl 
+libencode-detect-perl 
+libmodule-build-perl 
+libnet-ldap-perl 
+libauthen-sasl-perl 
+libtemplate-perl-doc 
+libfile-mimeinfo-perl 
+libhtml-formattext-withlinks-perl 
+libgd-dev 
+lynx-cur 
+python-sphinx
 


### PR DESCRIPTION
My update of Bugzilla includes a ton of packages (Debian and cpan/perl) that the previous version didn't. It happened because I included all the packages recommended by the Bugzilla install directions on their wiki and then those from the install script.

So I ended up with quite a few more packages installed than the previous version had. A lot of them are 'optional' extras that provide additional functionality. And I left it as was as I didn't want to start removing bits on a trial and error basis...

Totally open to feedback though...
