### PR TITLE
download from github - git.mozilla down at the moment

### DIFF
--- a/conf.d/downloads
+++ b/conf.d/downloads
@@ -1,3 +1,3 @@
 #!/bin/bash -ex
 
-git clone --depth 1 -b release-5.0-stable https://git.mozilla.org/bugzilla/bugzilla /var/www/bugzilla
+git clone --depth 1 -b release-5.0-stable https://github.com/bugzilla/bugzilla.git /var/www/bugzilla


### PR DESCRIPTION
Unfortunately git.mozilla.org is down at the moment but they use github as a read-only mirror so we can use that for now...
